### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -1,0 +1,99 @@
+name: Build BlueGriffon
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout BlueGriffon
+        uses: actions/checkout@v3
+        with:
+          path: bluegriffon
+
+      - name: Fetch gecko-dev
+        run: |
+          GECKO_REV=$(cat bluegriffon/config/gecko_dev_revision.txt)
+          git clone https://github.com/mozilla/gecko-dev.git bluegriffon-source
+          cd bluegriffon-source
+          git checkout $GECKO_REV
+          mv ../bluegriffon ./bluegriffon
+          patch -p 1 < bluegriffon/config/gecko_dev_content.patch
+          patch -p 1 < bluegriffon/config/gecko_dev_idl.patch
+          cp bluegriffon/config/mozconfig.ubuntu64 .mozconfig
+
+      - name: Bootstrap build dependencies
+        run: |
+          cd bluegriffon-source
+          ./mach --no-interactive bootstrap --application-choice=browser
+
+      - name: Build
+        run: |
+          cd bluegriffon-source
+          ./mach build
+
+      - name: Package
+        run: |
+          cd bluegriffon-source
+          ./mach package
+
+      - name: Upload Linux package
+        uses: actions/upload-artifact@v3
+        with:
+          name: bluegriffon-linux
+          path: bluegriffon-source/obj*/dist/*
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout BlueGriffon
+        uses: actions/checkout@v3
+        with:
+          path: bluegriffon
+
+      - name: Fetch gecko-dev
+        shell: bash
+        run: |
+          GECKO_REV=$(cat bluegriffon/config/gecko_dev_revision.txt)
+          git clone https://github.com/mozilla/gecko-dev.git bluegriffon-source
+          cd bluegriffon-source
+          git checkout $GECKO_REV
+          mv ../bluegriffon ./bluegriffon
+          patch -p 1 < bluegriffon/config/gecko_dev_content.patch
+          patch -p 1 < bluegriffon/config/gecko_dev_idl.patch
+          cp bluegriffon/config/mozconfig.win .mozconfig
+
+      - name: Bootstrap build dependencies
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          ./mach --no-interactive bootstrap --application-choice=browser
+
+      - name: Build
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          ./mach build
+
+      - name: Package
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          ./mach package
+
+      - name: Build installer
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          MOZ_MAKE=mozmake ./mach installer
+
+      - name: Upload Windows package
+        uses: actions/upload-artifact@v3
+        with:
+          name: bluegriffon-windows
+          path: bluegriffon-source/obj*/dist/*
+


### PR DESCRIPTION
## Summary
- add build workflow for Linux and Windows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868f5c0c39c8327b67bb71106321720