### PR TITLE
Add GitHub workflow for building installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf2.13 yasm libgtk-3-dev libdbus-1-dev libpulse-dev ccache
+
+      - name: Fetch Gecko source
+        run: |
+          GECKO_REV=$(cat bluegriffon/config/gecko_dev_revision.txt)
+          git clone --depth 1 --branch "$GECKO_REV" https://github.com/mozilla/gecko-dev ../gecko
+          cd ../gecko
+          patch -p1 < ../bluegriffon/config/gecko_dev_content.patch
+          patch -p1 < ../bluegriffon/config/gecko_dev_idl.patch
+          ln -s ../bluegriffon bluegriffon
+
+      - name: Setup build configuration
+        run: |
+          cp bluegriffon/config/mozconfig.ubuntu64 .mozconfig
+
+      - name: Build application
+        run: |
+          ./mach build
+          ./mach package
+          make -C bluegriffon/installer installer
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: bluegriffon
+          path: |
+            obj*/dist/*
+            bluegriffon/installer/*
+


### PR DESCRIPTION
## Summary
- add a workflow that checks out gecko-dev, applies BlueGriffon patches, and builds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868f5c0c39c8327b67bb71106321720