### PR TITLE
Limit workflow to Windows builds

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -1,0 +1,66 @@
+name: Build BlueGriffon
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout BlueGriffon
+        uses: actions/checkout@v3
+        with:
+          path: bluegriffon
+
+      - name: Install Python 2
+        shell: powershell
+        run: |
+          choco install python2 --no-progress -y
+          echo "C:\\Python27" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          python --version
+
+      - name: Fetch gecko-dev
+        shell: bash
+        run: |
+          GECKO_REV=$(cat bluegriffon/config/gecko_dev_revision.txt)
+          git clone https://github.com/mozilla/gecko-dev.git bluegriffon-source
+          cd bluegriffon-source
+          git checkout $GECKO_REV
+          mv ../bluegriffon ./bluegriffon
+          patch -p 1 < bluegriffon/config/gecko_dev_content.patch
+          patch -p 1 < bluegriffon/config/gecko_dev_idl.patch
+          cp bluegriffon/config/mozconfig.win .mozconfig
+
+      - name: Bootstrap build dependencies
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          /c/Python27/python.exe mach --no-interactive bootstrap --application-choice=browser
+
+      - name: Build
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          /c/Python27/python.exe mach build
+
+      - name: Package
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          /c/Python27/python.exe mach package
+
+      - name: Build installer
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          MOZ_MAKE=mozmake /c/Python27/python.exe mach installer
+
+      - name: Upload Windows package
+        uses: actions/upload-artifact@v4
+        with:
+          name: bluegriffon-windows
+          path: bluegriffon-source/obj*/dist/*
+


### PR DESCRIPTION
## Summary
- remove Linux workflow job
- update upload-artifact action to v4
- add Python 2 installation and call mach with Python 2 to avoid Python 3 errors

## Testing
- `true`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868f5c0c39c8327b67bb71106321720