### PR TITLE
Limit workflow to Windows builds

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -1,0 +1,63 @@
+name: Build BlueGriffon
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-windows:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout BlueGriffon
+        uses: actions/checkout@v3
+        with:
+          path: bluegriffon
+
+      - name: Install Python 2
+        shell: powershell
+        run: choco install python2 --no-progress -y
+
+      - name: Fetch gecko-dev
+        shell: bash
+        run: |
+          GECKO_REV=$(cat bluegriffon/config/gecko_dev_revision.txt)
+          git clone https://github.com/mozilla/gecko-dev.git bluegriffon-source
+          cd bluegriffon-source
+          git checkout $GECKO_REV
+          mv ../bluegriffon ./bluegriffon
+          patch -p 1 < bluegriffon/config/gecko_dev_content.patch
+          patch -p 1 < bluegriffon/config/gecko_dev_idl.patch
+          cp bluegriffon/config/mozconfig.win .mozconfig
+
+      - name: Bootstrap build dependencies
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          py -2 ./mach --no-interactive bootstrap
+
+      - name: Build
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          py -2 ./mach build
+
+      - name: Package
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          py -2 ./mach package
+
+      - name: Build installer
+        shell: bash
+        run: |
+          cd bluegriffon-source
+          MOZ_MAKE=mozmake py -2 ./mach installer
+
+      - name: Upload Windows package
+        uses: actions/upload-artifact@v4
+        with:
+          name: bluegriffon-windows
+          path: bluegriffon-source/obj*/dist/*
+


### PR DESCRIPTION
## Summary
- build on the Windows `windows-2022` runner using Python 2
- fix bootstrap step so mach runs without deprecated argument
- upload artifacts using v4 of the action

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6868f5c0c39c8327b67bb71106321720