### PR TITLE
Fix mach bootstrap invocation

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           cd bluegriffon-source
-          py -2 ./mach --no-interactive bootstrap
+          py -2 ./mach bootstrap --no-interactive
 
       - name: Build
         shell: bash


### PR DESCRIPTION
## Summary
- fix the bootstrap step to place `--no-interactive` after `bootstrap`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686914a8615483278649275ff14741c6