### PR TITLE
Fix bootstrap command

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           cd bluegriffon-source
-          py -2 ./mach --no-interactive bootstrap
+          py -2 ./mach bootstrap --no-interactive
 
       - name: Build
         shell: bash
@@ -60,4 +60,3 @@ jobs:
         with:
           name: bluegriffon-windows
           path: bluegriffon-source/obj*/dist/*
-


### PR DESCRIPTION
## Summary
- update GitHub workflow to correctly pass `--no-interactive`
- drop trailing newline in workflow file

## Testing
- `yamllint .github/workflows/build-bluegriffon.yml`

------
https://chatgpt.com/codex/tasks/task_e_686914a8615483278649275ff14741c6