### PR TITLE
Fix bootstrap step in workflow

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           cd bluegriffon-source
-          py -2 ./mach --no-interactive bootstrap
+          py -2 ./mach bootstrap --no-interactive
 
       - name: Build
         shell: bash
@@ -60,4 +60,3 @@ jobs:
         with:
           name: bluegriffon-windows
           path: bluegriffon-source/obj*/dist/*
-


### PR DESCRIPTION
## Summary
- call `mach bootstrap` with the flag in the correct place
- confirm artifact uploads use `actions/upload-artifact@v4`

## Testing
- `yamllint -d relaxed .github/workflows/build-bluegriffon.yml`


------
https://chatgpt.com/codex/tasks/task_e_686914a8615483278649275ff14741c6