### PR TITLE
Fix Windows bootstrap step and note in README

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           cd bluegriffon-source
           py -2 ./mach bootstrap
+        env:
+          MOZ_WINDOWS_BOOTSTRAP: "1"
 
       - name: Build
         shell: bash

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This repository includes a GitHub Actions workflow at
 `.github/workflows/build-bluegriffon.yml`. It runs on GitHub's v4 hosted runner
 and uses `actions/upload-artifact@v4` to store the build output. Trigger the
 workflow from the Actions tab to build BlueGriffon on Windows.
+This workflow sets `MOZ_WINDOWS_BOOTSTRAP=1` to bypass the Windows bootstrap check.
+
 
 ## Want to contribute to BlueGriffon?
 


### PR DESCRIPTION
## Summary
- set `MOZ_WINDOWS_BOOTSTRAP` in the GitHub Actions workflow so bootstrap works on Windows
- clarify in README that the workflow sets this env var

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686921ef6fd0832781a6157ae528fffa