### PR TITLE
Fix Windows bootstrap in workflow

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -36,6 +36,7 @@ jobs:
         shell: bash
         run: |
           cd bluegriffon-source
+          export MOZ_WINDOWS_BOOTSTRAP=1
           py -2 ./mach bootstrap
 
       - name: Build

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ The Open Source next-generation Web Editor based on the rendering engine of Fire
 
 This repository includes a GitHub Actions workflow at
 `.github/workflows/build-bluegriffon.yml`. It runs on GitHub's v4 hosted runner
-and uses `actions/upload-artifact@v4` to store the build output. Trigger the
-workflow from the Actions tab to build BlueGriffon on Windows.
+and uses `actions/upload-artifact@v4` to store the build output. It sets the
+`MOZ_WINDOWS_BOOTSTRAP` environment variable to allow `mach bootstrap` to run
+under Windows. Trigger the workflow from the Actions tab to build BlueGriffon on
+Windows.
 
 ## Want to contribute to BlueGriffon?
 


### PR DESCRIPTION
## Summary
- fix Windows bootstrap by exporting `MOZ_WINDOWS_BOOTSTRAP=1`
- document the environment variable in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686921ef6fd0832781a6157ae528fffa