### PR TITLE
Add GitHub workflow for Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build executables
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Bootstrap build dependencies
+        run: ./mach bootstrap --application-choice=browser --no-interactive
+
+      - name: Build
+        run: ./mach build
+
+      - name: Package
+        run: ./mach package
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bluegriffon-build
+          path: obj-*/dist/**

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ The Open Source next-generation Web Editor based on the rendering engine of Fire
 
 `./mach package`
 
+## Continuous Integration
+
+This repository includes a GitHub Actions workflow at
+`.github/workflows/build.yml` that builds the Windows executables. The workflow
+uses the latest GitHub runner and `actions/upload-artifact@v4` to store build
+artifacts.
+
 ## Want to contribute to BlueGriffon?
 
 There are two ways to contribute:


### PR DESCRIPTION
## Summary
- add a Windows build workflow using new `upload-artifact@v4`
- document workflow in the README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d2cf7b2948327bd20ec057d36a865