### PR TITLE
Add workflow to build Windows EXE

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,41 @@
+name: Build Windows EXE
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          choco install -y mozilla-build innosetup
+
+      - name: Fetch Gecko source
+        run: |
+          git clone https://github.com/mozilla/gecko-dev C:\gecko-dev
+          cd C:\gecko-dev
+          git reset --hard $(Get-Content $Env:GITHUB_WORKSPACE\config\gecko_dev_revision.txt)
+          git apply $Env:GITHUB_WORKSPACE\config\gecko_dev_content.patch
+          git apply $Env:GITHUB_WORKSPACE\config\gecko_dev_idl.patch
+          Copy-Item $Env:GITHUB_WORKSPACE\* -Destination . -Recurse -Force
+
+      - name: Build and package
+        run: |
+          cd C:\gecko-dev
+          Copy-Item $Env:GITHUB_WORKSPACE\config\mozconfig.win .mozconfig -Force
+          ./mach build
+          ./mach package
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bluegriffon-exe
+          path: '**/*.exe'

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ The Open Source next-generation Web Editor based on the rendering engine of Fire
 
 `./mach package`
 
+## Continuous integration
+
+The repository provides a GitHub Actions workflow that builds the Windows
+version of BlueGriffon. The workflow clones the Gecko sources, applies the
+required patches and packages the application. The resulting executable is
+published as an artifact.
+
 ## Want to contribute to BlueGriffon?
 
 There are two ways to contribute:


### PR DESCRIPTION
## Summary
- automate Windows build through GitHub Actions
- document the CI workflow in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d2cf7b2948327bd20ec057d36a865