### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,30 @@
+name: Build Windows Executable
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest-4
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up build environment
+        run: |
+          git clone https://github.com/mozilla/gecko-dev bluegriffon-source
+          cd bluegriffon-source
+          git reset --hard $(cat bluegriffon/config/gecko_dev_revision.txt)
+          patch -p 1 < bluegriffon/config/gecko_dev_content.patch
+          patch -p 1 < bluegriffon/config/gecko_dev_idl.patch
+          copy bluegriffon\config\mozconfig.win .mozconfig
+      - name: Build and package
+        run: |
+          cd bluegriffon-source
+          ./mach build
+          ./mach package
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: BlueGriffon-setup
+          path: '**/setup.exe'

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ The Open Source next-generation Web Editor based on the rendering engine of Fire
 
 `./mach package`
 
+## Continuous Integration
+
+GitHub Actions builds the Windows installer using the workflow defined in
+`.github/workflows/build-windows.yml`. The workflow checks out the source,
+clones `gecko-dev`, applies BlueGriffon patches and packages the project on the
+v4 runner. The resulting `setup.exe` is uploaded using
+`actions/upload-artifact@v4`.
+
 ## Want to contribute to BlueGriffon?
 
 There are two ways to contribute:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Windows installer on v4 runners
- document CI workflow in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d2cf7b2948327bd20ec057d36a865