### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build BlueGriffon
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone Gecko sources
+        run: git clone --depth 1 https://github.com/mozilla/gecko-dev gecko
+
+      - name: Copy BlueGriffon into Gecko tree
+        run: |
+          mkdir gecko/bluegriffon
+          rsync -a --exclude=gecko --exclude='.git' ./ gecko/bluegriffon/
+
+      - name: Apply patches and build
+        working-directory: gecko
+        run: |
+          git reset --hard $(cat bluegriffon/config/gecko_dev_revision.txt)
+          patch -p1 < bluegriffon/config/gecko_dev_content.patch
+          patch -p1 < bluegriffon/config/gecko_dev_idl.patch
+          cp bluegriffon/config/mozconfig.ubuntu64 .mozconfig
+          ./mach build
+          ./mach package
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bluegriffon-build
+          path: gecko/opt/dist/

--- a/README.md
+++ b/README.md
@@ -76,3 +76,9 @@ There are two ways to contribute:
 
 1. Contribute code. That's just another OSS project, we're waiting for your Pull Requests!
 2. Contribute L10N. All happens only in the 'locales' directory. You can review the existing locales and proposed changes/fixes or submit a new locale in a Pull Request. In that case, you need to translate everything from en-US into a new locale beforeI can accept the PR.
+
+## Continuous Integration
+
+A GitHub Actions workflow defined in `.github/workflows/build.yml` builds BlueGriffon automatically.
+It clones the Gecko sources, applies the required patches and runs `./mach build` and `./mach package`.
+The packaged build is uploaded as an artifact on each push and pull request.


### PR DESCRIPTION
## Summary
- add workflow to build BlueGriffon and upload artifacts using actions v4
- document the new workflow in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d386bfad4832796b585e5ee21c9ad