### PR TITLE
Add Python setup to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build BlueGriffon
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout BlueGriffon
+        uses: actions/checkout@v4
+        with:
+          path: bluegriffon
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Clone Gecko Source
+        run: |
+          git clone https://github.com/mozilla/gecko-dev gecko
+          cd gecko
+          git reset --hard $(cat ../bluegriffon/config/gecko_dev_revision.txt)
+          patch -p 1 < ../bluegriffon/config/gecko_dev_content.patch
+          patch -p 1 < ../bluegriffon/config/gecko_dev_idl.patch
+          cp ../bluegriffon/config/mozconfig.ubuntu64 .mozconfig
+          ./mach build
+          ./mach package
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: bluegriffon-package
+          path: gecko/obj*/dist/*.tar.*

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ The Open Source next-generation Web Editor based on the rendering engine of Fire
 
 `./mach package`
 
+## Build on GitHub Actions
+
+A workflow file located at `.github/workflows/build.yml` mirrors the manual steps
+above. It downloads the Gecko sources, applies the BlueGriffon patches and
+builds a package on every push or pull request using GitHub's v4 runners.
+The workflow sets up Python 3.11 so that `./mach` runs correctly and uploads
+the resulting archive with `actions/upload-artifact@v4`.
+
 ## Want to contribute to BlueGriffon?
 
 There are two ways to contribute:


### PR DESCRIPTION
## Summary
- build BlueGriffon on GitHub with Python 3.11
- document new runner setup in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d386bfad4832796b585e5ee21c9ad