### PR TITLE
Pin Python version in CI

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -18,6 +18,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential autoconf2.13 clang python3 python3-pip patch rsync
 
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Clone Gecko sources
         run: |
           git clone https://github.com/mozilla/gecko-dev gecko-dev

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ The Open Source next-generation Web Editor based on the rendering engine of Fire
 
 `./mach package`
 
+## Continuous Integration
+
+GitHub Actions builds BlueGriffon using Python 3.11. This prevents failures
+from deprecated modules such as `imp` that were removed in Python 3.12.
+
 ## Want to contribute to BlueGriffon?
 
 There are two ways to contribute:


### PR DESCRIPTION
## Summary
- use `actions/setup-python` to ensure Python 3.11 in CI
- document the CI Python version in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d4502527c8327a2d1a0709922bb8a