### PR TITLE
Fix GitHub workflow with Python 3.11

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout BlueGriffon
         uses: actions/checkout@v4
 
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ The Open Source next-generation Web Editor based on the rendering engine of Fire
 
 `./mach build`
 
+BlueGriffon is also built automatically on GitHub using a workflow that sets up
+Python 3.11 to avoid compatibility issues with the “imp” module removal in newer
+runners.
+
 ## Run BlueGriffon in a temporary profile
 
 `./mach run`


### PR DESCRIPTION
## Summary
- install Python 3.11 in the build workflow
- document GitHub build workflow in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d4502527c8327a2d1a0709922bb8a