### PR TITLE
Fix CI build by pinning Python 3.10

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -18,6 +18,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential autoconf2.13 clang python3 python3-pip patch rsync
 
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: Clone Gecko sources
         run: |
           git clone https://github.com/mozilla/gecko-dev gecko-dev

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ The Open Source next-generation Web Editor based on the rendering engine of Fire
 
 `./mach build`
 
+**Note:** The build system currently relies on Python's `imp` module, which was
+removed in Python 3.12. Use Python 3.10 (or another version below 3.12) when
+running `./mach` locally or in CI.
+
 ## Run BlueGriffon in a temporary profile
 
 `./mach run`


### PR DESCRIPTION
## Summary
- pin Python 3.10 in the build workflow so `mach` uses a supported version
- document the Python requirement in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d4502527c8327a2d1a0709922bb8a