### PR TITLE
Fix CI Python version for mach build

### DIFF
--- a/.github/workflows/build-bluegriffon.yml
+++ b/.github/workflows/build-bluegriffon.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout BlueGriffon
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ The Open Source next-generation Web Editor based on the rendering engine of Fire
 
 `./mach build`
 
+When building on GitHub Actions the workflow [`build-bluegriffon.yml`](.github/workflows/build-bluegriffon.yml) uses the v4 runner and pins Python 3.11 to avoid
+`ModuleNotFoundError: No module named 'imp'` errors during `./mach build`.
+
 ## Run BlueGriffon in a temporary profile
 
 `./mach run`


### PR DESCRIPTION
## Summary
- set up Python 3.11 on the CI build job to avoid ModuleNotFoundError for `imp`
- document the workflow behavior in README

## Testing
- `./mach --help` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686d4502527c8327a2d1a0709922bb8a